### PR TITLE
Update index.html.erb

### DIFF
--- a/overlay/var/www/railsapp.overlay/app/views/cp/index.html.erb
+++ b/overlay/var/www/railsapp.overlay/app/views/cp/index.html.erb
@@ -41,8 +41,8 @@
 
                 <li>Check out the Ruby on Rails 
                 <a href="http://rubyonrails.org/">website</a>, 
-                <a href="http://wiki.rubyonrails.org/">wiki</a> and the
-                <a href="http://rubyonrails.org/documentation">
+                <a href="http://api.rubyonrails.org/">API</a> and the
+                <a href="http://guides.rubyonrails.org/">
                 documentation</a></li>
 
                 <li><a href="https://www.turnkeylinux.org/rails">


### PR DESCRIPTION
Previous links are broken, and so is http://rubyonrails.org/screencasts. But there is no official replacement for this, so IMO it should be either removed or replaced with something like https://gorails.com/