### PR TITLE
Work around weird issue with wget/bundler & ipv6 ips

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -14,6 +14,10 @@ service mysql start
 unset HTTP_PROXY http_proxy # just in case it's set somewhere else
 cd $WEBROOT
 
+# workaround weird bug where bundle fails on IPv6 addresses
+# wgetrc file shouldn't exist by default, but just in case
+mv /root/.wgetrc /root/.wgetrc.orig || true
+echo 'inet4_only = on' > /root/.wgetrc
 bundle install
 bundle add shakapacker --strict
 rails webpacker:install
@@ -73,3 +77,6 @@ rm -f $WEBROOT/public/index.html
 sed -i '/stimulus-loading/s|^|// |' $WEBROOT/app/javascript/controllers/index.js
 
 RAILS_ENV=production bundle exec rake assets:precompile
+
+# restore origin wgetrc if it exists
+mv /root/.wgetrc.orig /root/.wgetrc || true

--- a/conf.d/main
+++ b/conf.d/main
@@ -79,4 +79,4 @@ sed -i '/stimulus-loading/s|^|// |' $WEBROOT/app/javascript/controllers/index.js
 RAILS_ENV=production bundle exec rake assets:precompile
 
 # restore origin wgetrc if it exists
-mv /root/.wgetrc.orig /root/.wgetrc || true
+mv /root/.wgetrc.orig /root/.wgetrc || rm -f /root/.wgetrc


### PR DESCRIPTION
I was getting a 404 (and the build was failing) when trying to install gems via `bundler`. It seems that `bundler` uses `wget` behind the scenes and for some reason it wouldn't/couldn't connect via IPv6 IP address - AFAICT the default. I could reproduce the failure via `wget` and I can see it trying via IPv6.

FWIW the download via `curl` works (uses IPv4). The issue seems to actually be with the rubygems.org IPv6 DNS. I double checked via dig (querying Google Public DNS) and the AAAA record (IPv6) address matches the IPv6 IP that `wget` fails on.

This works around that by forcing `wget` to use IPv4. It also removes the IPv4 forcing config, although perhaps I should leave it there - And note it in the changelog?