### PR TITLE
18.0 update

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,8 @@ turnkey-rails-18.0 (1) turnkey; urgency=low
   * Install Ruby v3.3.0 (via rbenv) & Rails v7.1.3.
     [Zhenya Khvorostian <zhenya@turnkeylinux.org>]
 
+  * Configure bundler to fall back to IPv4 if IPv6 fails.
+
   * Ensure hashfile includes URL to public key - closes #1864.
 
   * Include webmin-logviewer module by default - closes #1866.

--- a/conf.d/main
+++ b/conf.d/main
@@ -14,6 +14,9 @@ service mysql start
 unset HTTP_PROXY http_proxy # just in case it's set somewhere else
 cd $WEBROOT
 
+# ensure that bundler falls back to IPv4 if IPv6 fails
+echo ':ipv4_fallback_enabled: true' >> ~/.gemrc
+
 bundle install
 bundle add shakapacker --strict
 rails webpacker:install


### PR DESCRIPTION
Configure `bundler` to fall back to IPv4 if IPv6 fails.